### PR TITLE
Update FourMcNativeCodeLoader.java

### DIFF
--- a/java/hadoop-4mc/src/main/java/com/hadoop/compression/fourmc/FourMcNativeCodeLoader.java
+++ b/java/hadoop-4mc/src/main/java/com/hadoop/compression/fourmc/FourMcNativeCodeLoader.java
@@ -33,6 +33,7 @@
 **/
 package com.hadoop.compression.fourmc;
 
+import java.io.File;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 


### PR DESCRIPTION
Allows loading the native libraries from LD_LIBRARY_PATH using Distributed Cache in Hadoop. Otherwise we need to put the native libraries in the $HADOOP_HOME/lib/native in all nodes.
