### PR TITLE
Add include path for OS X

### DIFF
--- a/native/Makefile
+++ b/native/Makefile
@@ -13,7 +13,7 @@ CC:=$(CC)
 CFLAGS?= -O3
 #CFLAGS?= -ggdb
 CFLAGS+= -std=c99 -Wall -Wextra -Wundef -Wshadow -Wstrict-prototypes -DLZ4_VERSION=\"$(RELEASE)\"
-FLAGS= -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+FLAGS= -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -I$(JAVA_HOME)/include/darwin $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man/man1


### PR DESCRIPTION
At least on my system, the include file path in the makefile is missing the path specific to OS X. I assume it will be similarly missed on other Mac systems.
