### PR TITLE
Added getName() and getFilePattern() methods

### DIFF
--- a/java/hadoop-4mc/src/main/java/com/hadoop/compression/fourmc/FourMcInputStream.java
+++ b/java/hadoop-4mc/src/main/java/com/hadoop/compression/fourmc/FourMcInputStream.java
@@ -337,6 +337,9 @@ public class FourMcInputStream extends BlockDecompressorStream {
 
     @Override
     public void close() throws IOException {
+        if ( decompressor == null ) {
+            return;
+        }
         byte[] b = new byte[4096];
         while (!decompressor.finished()) {
           decompressor.decompress(b, 0, b.length);

--- a/java/hadoop-4mc/src/main/java/com/hadoop/mapreduce/FourMcLineRecordReader.java
+++ b/java/hadoop-4mc/src/main/java/com/hadoop/mapreduce/FourMcLineRecordReader.java
@@ -76,6 +76,14 @@ public class FourMcLineRecordReader extends RecordReader<LongWritable, Text> {
     private final LongWritable key = new LongWritable();
     private final Text value = new Text();
 
+    public String getName() {
+        return "fourmc";
+    }
+
+    public String getFilePattern() {
+        return "\\.4mc";
+    }
+
     /**
      * Get the progress within the split.
      */

--- a/java/hadoop-4mc/src/main/java/com/hadoop/mapreduce/FourMcLineRecordReader.java
+++ b/java/hadoop-4mc/src/main/java/com/hadoop/mapreduce/FourMcLineRecordReader.java
@@ -81,7 +81,7 @@ public class FourMcLineRecordReader extends RecordReader<LongWritable, Text> {
     }
 
     public String getFilePattern() {
-        return "\\.4mc";
+        return "\\.4mc&";
     }
 
     /**


### PR DESCRIPTION
Added getName() and getFilePattern() methods to FourMcLineRecordReader.java.  These methods allow hadoop users to specify custom Record Readers in external applications like Hunk.
