### PR TITLE
Multiple changes running 4mz in Spark 2.2

### DIFF
--- a/java/hadoop-4mc/src/main/java/com/hadoop/compression/fourmc/ZstdDecompressor.java
+++ b/java/hadoop-4mc/src/main/java/com/hadoop/compression/fourmc/ZstdDecompressor.java
@@ -231,6 +231,9 @@ public class ZstdDecompressor implements Decompressor {
     public synchronized void reset() {
         finished = false;
         compressedDirectBufLen = 0;
+        if (uncompressedDirectBuf == null) {
+            uncompressedDirectBuf = DirectBufferPool.getInstance().allocate(directBufferSize);
+        }
         uncompressedDirectBuf.limit(directBufferSize);
         uncompressedDirectBuf.position(directBufferSize);
         userBufOff = userBufLen = 0;

--- a/java/hadoop-4mc/src/main/java/com/hadoop/compression/fourmc/ZstdDecompressor.java
+++ b/java/hadoop-4mc/src/main/java/com/hadoop/compression/fourmc/ZstdDecompressor.java
@@ -134,6 +134,9 @@ public class ZstdDecompressor implements Decompressor {
         if (!isCurrentBlockUncompressed()) {
             compressedDirectBufLen = Math.min(userBufLen, directBufferSize);
 
+            if (compressedDirectBuf == null) {
+                compressedDirectBuf = DirectBufferPool.getInstance().allocate(directBufferSize);
+            }
             compressedDirectBuf.rewind();
             ((ByteBuffer) compressedDirectBuf).put(userBuf, userBufOff,
                     compressedDirectBufLen);

--- a/java/hadoop-4mc/src/main/java/com/hadoop/mapreduce/FourMzTextInputFormat.java
+++ b/java/hadoop-4mc/src/main/java/com/hadoop/mapreduce/FourMzTextInputFormat.java
@@ -43,7 +43,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
  * Files are broken into lines. Either linefeed or carriage-return are used to signal end of line.
  * Keys are the position in the file, and values are the line of text.
  */
-public class FourMzTextInputFormat extends FourMcInputFormat {
+public class FourMzTextInputFormat extends FourMzInputFormat<LongWritable, Text> {
     @Override
     public RecordReader<LongWritable, Text> createRecordReader(InputSplit split, TaskAttemptContext taskAttempt) {
         return new FourMzLineRecordReader();

--- a/java/hadoop-4mc/src/main/resources/META-INF/services/org.apache.hadoop.io.compress.CompressionCodec
+++ b/java/hadoop-4mc/src/main/resources/META-INF/services/org.apache.hadoop.io.compress.CompressionCodec
@@ -1,0 +1,12 @@
+com.hadoop.compression.fourmc.FourMcCodec
+com.hadoop.compression.fourmc.FourMcHighCodec
+com.hadoop.compression.fourmc.FourMcMediumCodec
+com.hadoop.compression.fourmc.FourMcUltraCodec
+com.hadoop.compression.fourmc.FourMzCodec
+com.hadoop.compression.fourmc.FourMzHighCodec
+com.hadoop.compression.fourmc.FourMzMediumCodec
+com.hadoop.compression.fourmc.FourMzUltraCodec
+com.hadoop.compression.fourmc.Lz4Codec
+com.hadoop.compression.fourmc.Lz4HighCodec
+com.hadoop.compression.fourmc.Lz4MediumCodec
+com.hadoop.compression.fourmc.Lz4UltraCodec


### PR DESCRIPTION
Modern Hadoop does not require core-site.xml configurations
for codecs.

This allows the codec to work in Spark by adding the jar to the classpath. 
You can copy the jar to the spark jars directory.

Implementations that do not have JavaServices code will work the same as without this META-INF data.