### PR TITLE
Fix incomplete extension in FourMcTextInputFormat.java

### DIFF
--- a/java/hadoop-4mc/src/main/java/com/hadoop/mapreduce/FourMcTextInputFormat.java
+++ b/java/hadoop-4mc/src/main/java/com/hadoop/mapreduce/FourMcTextInputFormat.java
@@ -43,7 +43,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
  * Files are broken into lines. Either linefeed or carriage-return are used to signal end of line.
  * Keys are the position in the file, and values are the line of text.
  */
-public class FourMcTextInputFormat extends FourMcInputFormat {
+public class FourMcTextInputFormat extends FourMcInputFormat<LongWritable, Text> {
     @Override
     public RecordReader<LongWritable, Text> createRecordReader(InputSplit split, TaskAttemptContext taskAttempt) {
         return new FourMcLineRecordReader();


### PR DESCRIPTION
We have an issue where Scala complains about this not being an acceptable class of type `InputFormat[K, V]` when using Spark. Adding the K and V parts fixes the problem.