### PR TITLE
Builds for linux, osx and win64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@
 # ---------------------------------------------------------------------------------
 language: java
 
-os:
-  - linux
-
-jdk:
-  - oraclejdk8
+matrix:
+  include:
+    - os: linux
+    - os: osx
+      osx_image: xcode9.2
 
 before_install:
   - sudo hostname "$(hostname | cut -c1-63)"
@@ -39,11 +39,15 @@ before_install:
   - cat ~/.mavenrc
 
 install:
-  - cd native
-  - make all
-  # I guess we need to find a way of making this portable...
-  - cp libhadoop-4mc.so.1.1.0 ../java/hadoop-4mc/src/main/resources/com/hadoop/compression/fourmc/linux/amd64/libhadoop-4mc.so
-  - cd ../java
+  - cd native/cmake
+  # the FindJNI in the Travis image is too old for cmake + jdk8
+  - curl https://raw.githubusercontent.com/Kitware/CMake/master/Modules/FindJNI.cmake >FindJNI.cmake
+  - cmake -DCMAKE_BUILD_TYPE=Release .
+  - cmake --build . --config Release
+  # I guess we need to find a way of making this portable..
+  - if [ -f libhadoop-4mc.so ]; then cp libhadoop-4mc.so ../../java/hadoop-4mc/src/main/resources/com/hadoop/compression/fourmc/linux/amd64/libhadoop-4mc.so; fi
+  - if [ -f libhadoop-4mc.dylib ]; then cp libhadoop-4mc.dylib ../../java/hadoop-4mc/src/main/resources/com/hadoop/compression/fourmc/darwin/x86_64/libhadoop-4mc.so; fi
+  - cd ../../java
   - mvn -T 2C clean install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - cmake --build . --config Release
   # I guess we need to find a way of making this portable..
   - if [ -f libhadoop-4mc.so ]; then cp libhadoop-4mc.so ../../java/hadoop-4mc/src/main/resources/com/hadoop/compression/fourmc/linux/amd64/libhadoop-4mc.so; fi
-  - if [ -f libhadoop-4mc.dylib ]; then cp libhadoop-4mc.dylib ../../java/hadoop-4mc/src/main/resources/com/hadoop/compression/fourmc/darwin/x86_64/libhadoop-4mc.so; fi
+  - if [ -f libhadoop-4mc.dylib ]; then cp libhadoop-4mc.dylib ../../java/hadoop-4mc/src/main/resources/com/hadoop/compression/fourmc/darwin/x86_64/libhadoop-4mc.dylib; fi
   - cd ../../java
   - mvn -T 2C clean install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+image:
+  - Visual Studio 2017
+
+branches:
+  only:
+    - master
+    - appveyor
+
+environment:
+  matrix:
+    - BUILD_SYSTEM: CMake
+      GENERATOR: Visual Studio 15 2017 Win64
+      CONFIG_TYPE: Release
+
+
+build_script:
+  - cmake -G "Visual Studio 15 2017 Win64" ./native/cmake/CMakeLists.txt
+  - cmake --build ./native/cmake --config Release -- /property:Prefer32bit=false /p:Platform=x64
+  - cmake -E copy ./native/cmake/Release/hadoop-4mc.dll java/hadoop-4mc/src/main/resources/com/hadoop/compression/fourmc/win32/amd64/libhadoop-4mc.dll
+  - cd java
+  - mvn -T 2C clean install
+  - mvn verify

--- a/native/cmake/CMakeLists.txt
+++ b/native/cmake/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CPACK_PACKAGE_VERSION_MINOR 0)
 set(CPACK_PACKAGE_VERSION_PATCH 0)
 set(VERSION_STRING	" \"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}\" ")
 include(CPack)
+include(FindJNI)
 
 cmake_minimum_required (VERSION 2.6)
 INCLUDE (CheckTypeSize)
@@ -22,6 +23,12 @@ if(UNIX AND NOT APPLE AND BUILD_LIBS)
         add_definitions(-fPIC)
     endif()
 endif()
+
+IF (MSVC)
+    # MSVC is logs many inline warnings
+    add_definitions("/wd4710")
+    add_definitions("/wd4711")
+ENDIF()
 
 set(LZ4_DIR ../lz4/)
 set(ZSTD_DIR ../zstd/)

--- a/native/jniZStreamCompressor.c
+++ b/native/jniZStreamCompressor.c
@@ -127,7 +127,7 @@ JNIEXPORT jint JNICALL Java_com_hadoop_compression_fourmc_zstd_ZstdStreamCompres
 
     void *dst_buff = (*env)->GetDirectBufferAddress(env, dst);
     if (dst_buff != NULL) {
-      ZSTD_outBuffer output = { dst_buff + dst_offset, dst_size, 0 };
+      ZSTD_outBuffer output = { ((char *)dst_buff) + dst_offset, dst_size, 0 };
       size = ZSTD_endStream((ZSTD_CStream *) stream, &output);
       size_t o_buff_len = dst_offset + output.pos;
       (*env)->SetLongField(env, this, dst_pos_id, output.pos);


### PR DESCRIPTION
Changes for builds on travis-ci.org for linux and osx.
The Win64 build can be run on https://www.appveyor.com as a free open source project.
OS X has a test failure that I need to investigate.  But it is building and running the tests.

You can see my test runs here.  https://ci.appveyor.com/project/snoe925/4mc

I am doing all the builds with cmake.  The cmake build is quite simple on appveyor.  That takes care of all the odd compiler and build settings.