### PR TITLE
Consolidate the Hadoop version

### DIFF
--- a/java/examples/pom.xml
+++ b/java/examples/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>examples</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <hadoop.version>2.6.0</hadoop.version>
+    </properties>
+
     <dependencies>
 
         <!-- 4mc -->
@@ -34,7 +38,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.6.0</version>
+            <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -49,7 +53,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-app</artifactId>
-            <version>2.6.0</version>
+            <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -60,7 +64,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-common</artifactId>
-            <version>2.6.0</version>
+            <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -75,7 +79,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
-            <version>2.6.0</version>
+            <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -91,7 +95,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
-            <version>2.6.0</version>
+            <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>
@@ -103,7 +107,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-yarn-api</artifactId>
-            <version>2.6.2</version>
+            <version>${hadoop.version}</version>
         </dependency>
 
         <dependency>
@@ -123,7 +127,5 @@
             <artifactId>protobuf-java</artifactId>
             <version>2.5.0</version>
         </dependency>
-
-
     </dependencies>
 </project>


### PR DESCRIPTION
We're using both 2.6.2 and 2.6.0. I think it would be a good idea to consolidate this into a property.