### PR TITLE
Bump Spark to 2.4.3

### DIFF
--- a/java/examples/pom.xml
+++ b/java/examples/pom.xml
@@ -26,8 +26,8 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
-            <version>2.3.2</version>
+            <artifactId>spark-core_2.12</artifactId>
+            <version>2.4.3</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
So we can make sure that it compiles and runs against the latest version of Spark.

Green CI: https://travis-ci.org/Fokko/4mc/builds/541141671